### PR TITLE
IDT-14 Update docs to point to Cloudflare Pages URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,10 +91,10 @@ Before opening a PR verify:
 
 ## Deployment
 
-GitHub Pages deploys automatically on every merge to `main`. No manual deploy step needed. The live site updates within ~60 seconds at:
+Cloudflare Pages deploys automatically on every merge to `main`. No manual deploy step needed. The live site updates within ~60 seconds at:
 
 ```
-https://bmschimmel.github.io/galactic-math
+https://galactic-math.pages.dev/
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Space themed math trainer for elementary school kids
 
 ## 🚀 Play It Now
 
-👉 **[Launch Galactic Math Academy](https://bmschimmel.github.io/galactic-math)**
+👉 **[Launch Galactic Math Academy](https://galactic-math.pages.dev/)**
 
 Or download `index.html` and open it in any modern browser.
 


### PR DESCRIPTION
Fixes IDT-14

Updated all documentation to reflect the move from GitHub Pages to Cloudflare Pages.

## Changes
- `README.md`: Updated launch link to `https://galactic-math.pages.dev/`
- `CONTRIBUTING.md`: Updated Deployment section — replaced GitHub Pages reference with Cloudflare Pages and updated the URL

## Testing
No functional changes — documentation only.