### PR TITLE
IDT-13 Add feedback footer and feedback page

### DIFF
--- a/index.html
+++ b/index.html
@@ -819,6 +819,30 @@
     color: var(--saber-blue);
     box-shadow: 0 0 10px var(--glow-blue);
   }
+
+  /* ===== FOOTER ===== */
+  .page-footer {
+    position: fixed;
+    bottom: 14px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10;
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  .page-footer a {
+    font-family: 'Exo 2', sans-serif;
+    font-size: 11px;
+    letter-spacing: 1px;
+    color: var(--muted);
+    text-decoration: none;
+    transition: color 0.2s;
+  }
+
+  .page-footer a:hover {
+    color: var(--saber-blue);
+  }
 </style>
 </head>
 <body>
@@ -1936,5 +1960,10 @@ function showScreen(name) {
   }
 }
 </script>
+
+<footer class="page-footer">
+  <a href="pages/feedback.html">💬 Got an idea or found a bug?</a>
+</footer>
+
 </body>
 </html>

--- a/pages/feedback.html
+++ b/pages/feedback.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Send Feedback — Galactic Math Academy</title>
+<link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Exo+2:wght@300;400;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --space-black: #030712;
+    --deep-space: #0a0f1e;
+    --nebula-blue: #1a2744;
+    --saber-blue: #00d4ff;
+    --saber-green: #39ff14;
+    --saber-red: #ff2d55;
+    --gold: #ffd700;
+    --star-white: #e8f4ff;
+    --muted: #6b7fa3;
+    --glow-blue: rgba(0, 212, 255, 0.3);
+    --glow-green: rgba(57, 255, 20, 0.3);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    background: var(--space-black);
+    color: var(--star-white);
+    font-family: 'Exo 2', sans-serif;
+    min-height: 100vh;
+    overflow-x: hidden;
+    position: relative;
+  }
+
+  body::before {
+    content: '';
+    position: fixed;
+    top: -20%; left: -20%;
+    width: 70%; height: 70%;
+    background: radial-gradient(ellipse, rgba(26, 39, 68, 0.6) 0%, transparent 70%);
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  body::after {
+    content: '';
+    position: fixed;
+    bottom: -20%; right: -20%;
+    width: 60%; height: 60%;
+    background: radial-gradient(ellipse, rgba(60, 20, 80, 0.4) 0%, transparent 70%);
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  #starfield {
+    position: fixed;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .container {
+    position: relative;
+    z-index: 1;
+    max-width: 600px;
+    margin: 0 auto;
+    padding: 40px 20px 60px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* ===== HEADER ===== */
+  .back-link {
+    align-self: flex-start;
+    font-family: 'Orbitron', monospace;
+    font-size: 10px;
+    letter-spacing: 3px;
+    color: var(--muted);
+    text-decoration: none;
+    margin-bottom: 32px;
+    transition: color 0.2s;
+  }
+
+  .back-link:hover { color: var(--saber-blue); }
+
+  .title-main {
+    font-family: 'Orbitron', monospace;
+    font-size: clamp(22px, 5vw, 36px);
+    font-weight: 900;
+    letter-spacing: 4px;
+    background: linear-gradient(180deg, #fff 0%, var(--gold) 50%, #c8860a 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    filter: drop-shadow(0 0 16px rgba(255, 215, 0, 0.4));
+    text-align: center;
+    margin-bottom: 6px;
+  }
+
+  .title-sub {
+    font-family: 'Orbitron', monospace;
+    font-size: clamp(9px, 1.8vw, 12px);
+    letter-spacing: 6px;
+    color: var(--saber-blue);
+    text-transform: uppercase;
+    text-align: center;
+    margin-bottom: 32px;
+    filter: drop-shadow(0 0 6px var(--saber-blue));
+  }
+
+  /* ===== CARD ===== */
+  .feedback-card {
+    width: 100%;
+    background: rgba(10, 15, 30, 0.85);
+    border: 1px solid rgba(0, 212, 255, 0.2);
+    border-radius: 16px;
+    padding: 32px;
+    backdrop-filter: blur(10px);
+    box-shadow: 0 0 40px rgba(0, 212, 255, 0.06), inset 0 0 60px rgba(0, 0, 0, 0.3);
+  }
+
+  .field-label {
+    font-family: 'Orbitron', monospace;
+    font-size: 10px;
+    letter-spacing: 4px;
+    color: var(--saber-blue);
+    text-transform: uppercase;
+    display: block;
+    margin-bottom: 8px;
+  }
+
+  .field-input {
+    width: 100%;
+    padding: 12px 16px;
+    background: rgba(0, 212, 255, 0.05);
+    border: 1px solid rgba(0, 212, 255, 0.2);
+    border-radius: 8px;
+    color: var(--star-white);
+    font-family: 'Exo 2', sans-serif;
+    font-size: 15px;
+    outline: none;
+    transition: all 0.2s;
+    margin-bottom: 24px;
+  }
+
+  .field-input:focus {
+    border-color: var(--saber-blue);
+    box-shadow: 0 0 16px var(--glow-blue);
+    background: rgba(0, 212, 255, 0.08);
+  }
+
+  .field-textarea {
+    resize: vertical;
+    min-height: 120px;
+    line-height: 1.5;
+  }
+
+  .error-msg {
+    color: var(--saber-red);
+    font-size: 12px;
+    letter-spacing: 1px;
+    font-family: 'Orbitron', monospace;
+    min-height: 18px;
+    margin-bottom: 16px;
+  }
+
+  .btn-primary {
+    width: 100%;
+    padding: 16px;
+    background: linear-gradient(135deg, rgba(0, 212, 255, 0.15), rgba(0, 100, 200, 0.15));
+    border: 1px solid var(--saber-blue);
+    border-radius: 10px;
+    color: var(--saber-blue);
+    font-family: 'Orbitron', monospace;
+    font-size: 13px;
+    letter-spacing: 3px;
+    cursor: pointer;
+    transition: all 0.25s;
+    text-transform: uppercase;
+    box-shadow: 0 0 20px rgba(0, 212, 255, 0.1);
+  }
+
+  .btn-primary:hover {
+    background: linear-gradient(135deg, rgba(0, 212, 255, 0.25), rgba(0, 100, 200, 0.25));
+    box-shadow: 0 0 30px rgba(0, 212, 255, 0.3);
+    transform: translateY(-1px);
+  }
+
+  .saber-divider {
+    width: 100%;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--saber-blue), transparent);
+    margin: 24px 0;
+    box-shadow: 0 0 6px var(--saber-blue);
+  }
+
+  /* ===== CONFIRMATION ===== */
+  .confirm-state {
+    display: none;
+    text-align: center;
+  }
+
+  .confirm-icon {
+    font-size: 56px;
+    margin-bottom: 16px;
+    animation: spin-in 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  }
+
+  @keyframes spin-in {
+    from { transform: scale(0) rotate(-180deg); opacity: 0; }
+    to { transform: scale(1) rotate(0deg); opacity: 1; }
+  }
+
+  .confirm-title {
+    font-family: 'Orbitron', monospace;
+    font-size: 18px;
+    font-weight: 900;
+    letter-spacing: 3px;
+    color: var(--saber-green);
+    filter: drop-shadow(0 0 10px var(--saber-green));
+    margin-bottom: 12px;
+  }
+
+  .confirm-body {
+    color: var(--muted);
+    font-size: 14px;
+    line-height: 1.6;
+    margin-bottom: 28px;
+  }
+
+  .confirm-body a {
+    color: var(--saber-blue);
+    text-decoration: none;
+  }
+
+  .confirm-body a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+
+<canvas id="starfield"></canvas>
+
+<div class="container">
+  <a href="../index.html" class="back-link">← BACK TO GALACTIC MATH</a>
+
+  <div class="title-main">SEND A TRANSMISSION</div>
+  <div class="title-sub">Report a bug · Share an idea</div>
+
+  <div class="feedback-card">
+
+    <!-- FORM STATE -->
+    <div id="formState">
+      <span class="field-label">▸ Your name</span>
+      <input type="text" class="field-input" id="inputName"
+             placeholder="Han Solo" maxlength="80"
+             onkeydown="if(event.key==='Enter') document.getElementById('inputMessage').focus()">
+
+      <span class="field-label">▸ What's your idea or what's broken?</span>
+      <textarea class="field-input field-textarea" id="inputMessage"
+                placeholder="Tell us what you'd like to see, or describe the bug..."
+                maxlength="2000"></textarea>
+
+      <div class="error-msg" id="errorMsg"></div>
+
+      <div class="saber-divider"></div>
+
+      <button class="btn-primary" onclick="submitFeedback()">
+        📡 TRANSMIT FEEDBACK
+      </button>
+    </div>
+
+    <!-- CONFIRMATION STATE -->
+    <div class="confirm-state" id="confirmState">
+      <div class="confirm-icon">📡</div>
+      <div class="confirm-title">TRANSMISSION SENT!</div>
+      <div class="confirm-body">
+        We've opened GitHub so you can submit your request.<br><br>
+        Once submitted, you can track it at<br>
+        <a href="https://github.com/bmschimmel/galactic-math/issues" target="_blank">
+          github.com/bmschimmel/galactic-math/issues
+        </a>
+      </div>
+      <button class="btn-primary" onclick="window.location.href='../index.html'">
+        🚀 BACK TO TRAINING
+      </button>
+    </div>
+
+  </div>
+</div>
+
+<script>
+// ===== STARS =====
+(function() {
+  const canvas = document.getElementById('starfield');
+  const ctx = canvas.getContext('2d');
+  let stars = [];
+
+  function resize() {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    stars = [];
+    const count = Math.floor((canvas.width * canvas.height) / 6000);
+    for (let i = 0; i < count; i++) {
+      stars.push({
+        x: Math.random() * canvas.width,
+        y: Math.random() * canvas.height,
+        r: Math.random() * 1.5 + 0.2,
+        speed: Math.random() * 0.008 + 0.002,
+        phase: Math.random() * Math.PI * 2
+      });
+    }
+  }
+
+  function draw(t) {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    stars.forEach(s => {
+      const op = 0.15 + 0.85 * (0.5 + 0.5 * Math.sin(t * s.speed * 1000 + s.phase));
+      ctx.beginPath();
+      ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(220, 240, 255, ${op})`;
+      ctx.fill();
+    });
+    requestAnimationFrame(draw);
+  }
+
+  window.addEventListener('resize', resize);
+  resize();
+  requestAnimationFrame(draw);
+})();
+
+// ===== FEEDBACK =====
+function submitFeedback() {
+  const name = document.getElementById('inputName').value.trim();
+  const message = document.getElementById('inputMessage').value.trim();
+  const errorEl = document.getElementById('errorMsg');
+
+  if (!name) { errorEl.textContent = '⚠ Enter your name'; return; }
+  if (!message) { errorEl.textContent = '⚠ Tell us your idea or what\'s broken'; return; }
+  errorEl.textContent = '';
+
+  const title = encodeURIComponent(`[Feedback] ${name}: ${message.slice(0, 60)}${message.length > 60 ? '…' : ''}`);
+  const body = encodeURIComponent(`**From:** ${name}\n\n**Message:**\n${message}`);
+  const url = `https://github.com/bmschimmel/galactic-math/issues/new?title=${title}&body=${body}`;
+
+  window.open(url, '_blank');
+
+  document.getElementById('formState').style.display = 'none';
+  document.getElementById('confirmState').style.display = 'block';
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes IDT-13

Adds a user-facing feedback flow so anyone can report bugs or share ideas without needing to know GitHub.

## Changes

### `index.html`
- Added a subtle fixed footer link: _"💬 Got an idea or found a bug?"_ → routes to `pages/feedback.html`

### `pages/feedback.html` (new)
- Space-themed feedback page styled to match the main app (same fonts, CSS variables, starfield)
- Form fields: **Your name** + **What's your idea or what's broken?**
- On submit: pre-fills a GitHub new issue with the user's name and message, opens it in a new tab
- Shows a confirmation state with a link to track the issue at `github.com/bmschimmel/galactic-math/issues`
- No backend or API keys required — GitHub handles issue creation

## Testing
Open `index.html` in a browser and verify:
- [ ] Footer link is visible and routes to `pages/feedback.html`
- [ ] Feedback form validates empty name / empty message
- [ ] Submitting opens a pre-filled GitHub new issue in a new tab
- [ ] Confirmation screen appears after submit with tracking link
- [ ] "Back to Training" button returns to main app
- [ ] Page is usable on mobile (~375px wide)