### PR TITLE
IDT-17 Update hyperspace mode timer settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -902,10 +902,9 @@
       <div id="hyperspaceOptions" style="display:none;">
         <span class="setup-label" style="font-size:10px; margin-bottom:10px; margin-top:4px;">▸ Time limit</span>
         <div class="quick-btns" id="difficultyBtns" style="flex-wrap:wrap;">
-          <button class="quick-btn mode-btn selected-mode" data-diff="wicked-easy" onclick="setDifficulty('wicked-easy')">😌 Wicked Easy (10m)</button>
-          <button class="quick-btn mode-btn" data-diff="kind-of-easy" onclick="setDifficulty('kind-of-easy')">🙂 Kind of Easy (5m)</button>
-          <button class="quick-btn mode-btn" data-diff="hard" onclick="setDifficulty('hard')">😤 Hard (3m)</button>
-          <button class="quick-btn mode-btn" data-diff="falcon" onclick="setDifficulty('falcon')">🦅 Falcon Mode (2m)</button>
+          <button class="quick-btn mode-btn selected-mode" data-diff="wicked-easy" onclick="setDifficulty('wicked-easy')">😌 Wicked Easy (5m)</button>
+          <button class="quick-btn mode-btn" data-diff="harder" onclick="setDifficulty('harder')">😤 Harder (1m)</button>
+          <button class="quick-btn mode-btn" data-diff="hyperdrive" onclick="setDifficulty('hyperdrive')">⚡ Hyperdrive (30s)</button>
         </div>
       </div>
 
@@ -1484,7 +1483,7 @@ let selectedOps = new Set(['multiply']);
 // Hyperspace mode state
 let hyperspaceEnabled = false;
 let hyperspaceDiff = 'wicked-easy';
-const HYPERSPACE_LIMITS = { 'wicked-easy': 600, 'kind-of-easy': 300, 'hard': 180, 'falcon': 120 };
+const HYPERSPACE_LIMITS = { 'wicked-easy': 300, 'harder': 60, 'hyperdrive': 30 };
 let hyperspaceTimer = null;
 let hyperspaceTimeRemaining = 0;
 let hyperspaceHalfwayShown = false;


### PR DESCRIPTION
Fixes IDT-17

Replaces the 4 old difficulty tiers with 3 new ones and adjusts all time limits.

## Changes

| | Before | After |
|---|---|---|
| Tier 1 | 😌 Wicked Easy — 10m | 😌 Wicked Easy — 5m |
| Tier 2 | 🙂 Kind of Easy — 5m | 😤 Harder — 1m |
| Tier 3 | 😤 Hard — 3m | ⚡ Hyperdrive — 30s |
| Tier 4 | 🦅 Falcon Mode — 2m | *(removed)* |

Default selection remains Wicked Easy.

## Testing
- Enable Hyperspace mode and verify 3 difficulty buttons appear with correct labels
- Wicked Easy is pre-selected by default
- Start a quiz on each tier and confirm the countdown starts at 5:00 / 1:00 / 0:30 respectively