### PR TITLE
IDT-16 General UX improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,10 +332,6 @@
   .tile-icon {
     font-size: 24px;
     flex-shrink: 0;
-    transition: filter 0.3s;
-  }
-  .game-mode-tile-btn.selected-mode .tile-icon {
-    filter: drop-shadow(0 0 8px var(--saber-green)) drop-shadow(0 0 16px var(--saber-green));
   }
   .tile-body {
     flex: 1;
@@ -378,17 +374,17 @@
     transition: all 0.3s;
   }
   .game-mode-tile-btn.selected-mode .tile-badge {
-    color: var(--saber-blue);
-    border-color: var(--saber-blue);
-    background: rgba(0, 212, 255, 0.12);
-    box-shadow: 0 0 10px rgba(0, 212, 255, 0.25), inset 0 0 8px rgba(0, 212, 255, 0.08);
-    text-shadow: 0 0 8px var(--saber-blue);
+    color: var(--saber-green);
+    border-color: var(--saber-green);
+    background: rgba(57, 255, 20, 0.1);
+    box-shadow: 0 0 10px rgba(57, 255, 20, 0.3), inset 0 0 8px rgba(57, 255, 20, 0.08);
+    text-shadow: 0 0 8px var(--saber-green);
   }
   .game-mode-tile-btn.selected-mode .tile-badge::before {
     content: '◉';
     opacity: 1;
-    color: var(--saber-blue);
-    filter: drop-shadow(0 0 4px var(--saber-blue));
+    color: var(--saber-green);
+    filter: drop-shadow(0 0 4px var(--saber-green));
   }
   @media (max-width: 480px) {
     .game-mode-tiles { flex-direction: column; }


### PR DESCRIPTION
Fixes IDT-16

## Changes

- **Default selection**: Numbers 2–12 pre-selected (not 0–12); grid splits at 6 for visual clarity
- **Minimum validation**: Must select at least 3 numbers before starting
- **Setup sounds**: `sounds.navigate()` plays on every number/op toggle and quick-select
- **Restart mid-quiz**: ↺ RESTART button in quiz header — resets answers without reshuffling
- **Session scores (all modes)**: Regular mode now tracks and displays scores across runs in the session, matching Kessel Run behavior
- **Kessel Run icon**: Updated from 🏎️ to ☄️ for space consistency
- **Op mode button colors**: ×÷ buttons glow blue; +− buttons glow green
- **Game modes layout**: Hyperspace and Kessel Run panels displayed side-by-side
- **Favicon**: Inline SVG (no image file) — Saturn-style planet with gold ring

## Testing

Tested by opening `index.html` directly in browser:
- [ ] Default loads with 2–12 selected, 0 and 1 unselected
- [ ] Number grid splits: 0–5 on row 1, 6–12 on row 2
- [ ] Selecting fewer than 3 numbers shows error on Start
- [ ] Navigate sound plays when toggling numbers, ops, and quick-select buttons
- [ ] ↺ RESTART mid-quiz resets answers, stays on same question order
- [ ] Session scores appear after completing a regular (non-Kessel) run
- [ ] Kessel Run button shows ☄️ icon
- [ ] Op buttons: ×÷ glow blue, +− glow green
- [ ] Hyperspace and Kessel Run panels sit side-by-side