### PR TITLE
IDT-7 Add version number to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1541,6 +1541,7 @@
 
   <footer class="page-footer">
     Created for fun. Created for free. Have fun! &nbsp;·&nbsp; © Brendan Schimmel &nbsp;·&nbsp; <a href="pages/feedback.html">💬 Feedback</a>
+    <div style="margin-top:4px; opacity:0.4;">v1.0.0</div>
   </footer>
 
 </div>


### PR DESCRIPTION
Fixes IDT-7

Adds `v1.0.0` below the footer text, dimmed so it doesn't compete visually. Update the string manually when cutting a new release.