### PR TITLE
IDT-22 Add meta description, OG tags, and version footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,23 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Galactic Math Academy</title>
+<meta name="description" content="Space-themed math training for kids. Practice multiplication, division, addition, and subtraction with lightsabers, droids, and starships. Free, no login required.">
+
+<!-- Open Graph -->
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://galactic-math.pages.dev/">
+<meta property="og:title" content="Galactic Math Academy">
+<meta property="og:description" content="Space-themed math training for kids. Practice multiplication, division, addition, and subtraction with lightsabers, droids, and starships. Free, no login required.">
+<meta property="og:image" content="https://galactic-math.pages.dev/og-image.svg">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+
+<!-- Twitter Card -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Galactic Math Academy">
+<meta name="twitter:description" content="Space-themed math training for kids. Practice multiplication, division, addition, and subtraction with lightsabers, droids, and starships. Free, no login required.">
+<meta name="twitter:image" content="https://galactic-math.pages.dev/og-image.svg">
+
 <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Exo+2:wght@300;400;600&display=swap" rel="stylesheet">
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='4' fill='%23030712'/%3E%3Ccircle cx='16' cy='16' r='7' fill='%231a2744' stroke='%2300d4ff' stroke-width='1.5'/%3E%3Cellipse cx='16' cy='16' rx='12' ry='4.5' fill='none' stroke='%23ffd700' stroke-width='1.5' opacity='0.9'/%3E%3Ccircle cx='7' cy='8' r='1.2' fill='%23e8f4ff' opacity='0.7'/%3E%3Ccircle cx='26' cy='7' r='1' fill='%23e8f4ff' opacity='0.5'/%3E%3Ccircle cx='27' cy='24' r='1.2' fill='%23e8f4ff' opacity='0.6'/%3E%3C/svg%3E">
 <style>
@@ -1541,6 +1558,7 @@
 
   <footer class="page-footer">
     Created for fun. Created for free. Have fun! &nbsp;·&nbsp; © Brendan Schimmel &nbsp;·&nbsp; <a href="pages/feedback.html">💬 Feedback</a>
+    <div style="margin-top:4px; opacity:0.4;">v1.0.0</div>
   </footer>
 
 </div>

--- a/og-image.svg
+++ b/og-image.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <!-- Background -->
+  <rect width="1200" height="630" fill="#030712"/>
+  <!-- Nebula blobs -->
+  <ellipse cx="200" cy="150" rx="300" ry="200" fill="rgba(26,39,68,0.6)"/>
+  <ellipse cx="1050" cy="500" rx="280" ry="180" fill="rgba(60,20,80,0.4)"/>
+  <!-- Stars -->
+  <circle cx="80" cy="60" r="1.5" fill="#e8f4ff" opacity="0.7"/>
+  <circle cx="220" cy="30" r="1" fill="#e8f4ff" opacity="0.5"/>
+  <circle cx="450" cy="80" r="1.5" fill="#e8f4ff" opacity="0.6"/>
+  <circle cx="700" cy="20" r="1" fill="#e8f4ff" opacity="0.8"/>
+  <circle cx="950" cy="55" r="1.5" fill="#e8f4ff" opacity="0.5"/>
+  <circle cx="1100" cy="90" r="1" fill="#e8f4ff" opacity="0.7"/>
+  <circle cx="1180" cy="35" r="1.5" fill="#e8f4ff" opacity="0.4"/>
+  <circle cx="60" cy="400" r="1" fill="#e8f4ff" opacity="0.6"/>
+  <circle cx="340" cy="560" r="1.5" fill="#e8f4ff" opacity="0.5"/>
+  <circle cx="580" cy="590" r="1" fill="#e8f4ff" opacity="0.7"/>
+  <circle cx="870" cy="610" r="1.5" fill="#e8f4ff" opacity="0.4"/>
+  <circle cx="1150" cy="580" r="1" fill="#e8f4ff" opacity="0.6"/>
+  <!-- Planet / logo mark -->
+  <circle cx="600" cy="210" r="72" fill="#1a2744" stroke="#00d4ff" stroke-width="2.5"/>
+  <ellipse cx="600" cy="210" rx="115" ry="42" fill="none" stroke="#ffd700" stroke-width="2.5" opacity="0.9"/>
+  <circle cx="520" cy="160" r="8" fill="#e8f4ff" opacity="0.5"/>
+  <circle cx="690" cy="175" r="6" fill="#e8f4ff" opacity="0.4"/>
+  <circle cx="660" cy="250" r="7" fill="#e8f4ff" opacity="0.45"/>
+  <!-- Title -->
+  <text x="600" y="345" font-family="Arial Black, sans-serif" font-size="72" font-weight="900" fill="url(#titleGrad)" text-anchor="middle" letter-spacing="6">GALACTIC MATH</text>
+  <!-- Subtitle -->
+  <text x="600" y="400" font-family="Arial, sans-serif" font-size="28" fill="#00d4ff" text-anchor="middle" letter-spacing="10" opacity="0.9">ACADEMY</text>
+  <!-- Tagline -->
+  <text x="600" y="470" font-family="Arial, sans-serif" font-size="22" fill="#6b7fa3" text-anchor="middle" letter-spacing="3">Space-themed math training for kids</text>
+  <!-- URL -->
+  <text x="600" y="560" font-family="Arial, sans-serif" font-size="18" fill="#6b7fa3" text-anchor="middle" letter-spacing="2" opacity="0.7">galactic-math.pages.dev</text>
+  <!-- Gradient def -->
+  <defs>
+    <linearGradient id="titleGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="50%" stop-color="#ffd700"/>
+      <stop offset="100%" stop-color="#c8860a"/>
+    </linearGradient>
+  </defs>
+</svg>


### PR DESCRIPTION
Fixes IDT-22

## What changed

**`index.html`**
- `<meta name="description">` for SEO
- Open Graph tags (`og:title`, `og:description`, `og:image`, `og:url`, `og:type`) — sharing on Slack, iMessage, Discord will show a rich preview
- Twitter Card tags (`summary_large_image`)
- `v1.0.0` version label dimmed below footer text — update manually on each release

**`og-image.svg`** (new file)
- 1200×630 preview image served by Cloudflare Pages at `/og-image.svg`
- Matches the app's space aesthetic — dark background, planet logo, gold title gradient

> **Note:** Twitter/X requires a raster PNG for og:image. The SVG will work on Slack, Discord, and iMessage. If Twitter card previews are needed, convert `og-image.svg` to `og-image.png` and update the image URLs.