### PR TITLE
IDT-30 Add Reset button to operation mode selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -1459,6 +1459,7 @@
         <button class="quick-btn mode-btn op-add-sub" data-mode="add" onclick="toggleOp('add')">+ Add</button>
         <button class="quick-btn mode-btn op-add-sub" data-mode="subtract" onclick="toggleOp('subtract')">− Subtract</button>
         <button class="quick-btn mode-btn" data-mode="all" onclick="selectAllOps()">★ All</button>
+        <button class="quick-btn" onclick="resetOps()" style="border-color:rgba(107,127,163,0.3);color:var(--muted);">↺ Reset</button>
       </div>
 
       <div class="saber-divider" style="margin: 20px 0 16px;"></div>
@@ -2114,6 +2115,13 @@ function toggleOp(op) {
 
 function selectAllOps() {
   selectedOps = new Set(['multiply', 'divide', 'add', 'subtract']);
+  updateOpButtons();
+  sounds.navigate();
+  document.getElementById('setupError').textContent = '';
+}
+
+function resetOps() {
+  selectedOps = new Set(['multiply']);
   updateOpButtons();
   sounds.navigate();
   document.getElementById('setupError').textContent = '';


### PR DESCRIPTION
## Summary
- Added a **↺ Reset** button to the operation mode selector row that resets to the default (Multiply only)
- Gives users a reliable escape hatch if they get stuck in an unexpected selection state on mobile

## Test plan
- [ ] ↺ Reset button appears after ★ All in the operation mode row
- [ ] Clicking Reset selects only Multiply, deselecting everything else
- [ ] Navigation sound plays on reset
- [ ] ★ All still works normally

Fixes IDT-30

🤖 Generated with [Claude Code](https://claude.com/claude-code)