### PR TITLE
IDT-33 Add abort mission button to quiz screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,7 +448,14 @@
     }
   }
 
-  /* Restart button */
+  /* Restart / quit button row */
+  .quiz-actions {
+    display: flex;
+    justify-content: center;
+    gap: 24px;
+    margin-top: 10px;
+  }
+
   .restart-btn {
     background: transparent;
     border: none;
@@ -460,9 +467,24 @@
     padding: 6px 10px;
     transition: color 0.2s;
     display: block;
-    margin: 10px auto 0;
+    margin: 0;
   }
   .restart-btn:hover { color: var(--saber-red); }
+
+  .quit-btn {
+    background: transparent;
+    border: none;
+    color: var(--muted);
+    font-family: 'Orbitron', monospace;
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
+    cursor: pointer;
+    padding: 6px 12px;
+    transition: color 0.2s;
+    display: block;
+    margin: 0;
+  }
+  .quit-btn:hover { color: var(--star-white); }
 
   /* ===== BUTTONS ===== */
   .btn-primary {
@@ -1576,7 +1598,10 @@
     </div>
 
     <div class="nav-dots" id="navDots"></div>
-    <button class="restart-btn" onclick="restartQuiz()">↺ RESTART</button>
+    <div class="quiz-actions">
+      <button class="restart-btn" onclick="restartQuiz()">↺ RESTART</button>
+      <button class="quit-btn" onclick="newMission()">⌂ ABORT MISSION</button>
+    </div>
   </div>
 
   <!-- RESULTS SCREEN -->


### PR DESCRIPTION
Fixes IDT-33

## Summary
- Adds an **⌂ ABORT MISSION** button next to the existing RESTART button on the quiz screen
- Calls `newMission()` which already handles stopping all timers and navigating back to setup — session history is preserved
- Styled as a secondary muted button (same weight as RESTART), no new colors introduced

## How to test
- Start a quiz, answer a few questions, click ⌂ ABORT MISSION
- Confirm you land on the setup screen with number/op selections intact
- Open History modal — previous completed sessions should still be listed
- Verify Hyperspace and Kessel Run timers stop cleanly on abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)