### PR TITLE
IDT-34 Add observability logging to feedback worker

### DIFF
--- a/worker/feedback-worker.js
+++ b/worker/feedback-worker.js
@@ -45,6 +45,7 @@ export default {
     // Rate limit by IP
     const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
     if (isRateLimited(ip)) {
+      console.log(`Rate limited: ${ip}`);
       return new Response(JSON.stringify({ error: 'Too many requests. Try again later.' }), {
         status: 429,
         headers: { 'Content-Type': 'application/json', ...corsHeaders(origin) },
@@ -63,7 +64,7 @@ export default {
 
     // Honeypot check — bots fill hidden fields, humans leave them empty
     if (body.honeypot) {
-      // Return 200 to not tip off bots, but do nothing
+      console.log(`Honeypot triggered from ${ip}`);
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { 'Content-Type': 'application/json', ...corsHeaders(origin) },
@@ -99,6 +100,7 @@ export default {
     }
 
     const issue = await response.json();
+    console.log(`Issue created: ${issue.html_url} from ${ip}`);
     return new Response(JSON.stringify({ ok: true, url: issue.html_url }), {
       status: 200,
       headers: { 'Content-Type': 'application/json', ...corsHeaders(origin) },


### PR DESCRIPTION
Fixes IDT-34

## Summary
Adds three `console.log` lines to `worker/feedback-worker.js` so bot activity and real submissions are visible in the Cloudflare Worker Logs tab:

- `Honeypot triggered from <ip>` — bot filled the hidden field
- `Rate limited: <ip>` — IP exceeded 3 requests / 10 min
- `Issue created: <url> from <ip>` — legitimate submission went through

## How to view logs
Cloudflare dashboard → Workers & Pages → feedback-worker → **Logs** tab

After deploying, filter by keyword (`Honeypot`, `Rate limited`, `Issue created`) to see each category separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)