### PR TITLE
IDT-40 Enable observability logging config in wrangler.toml

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,3 +1,8 @@
 name = "galactic-math-feedback"
 main = "feedback-worker.js"
 compatibility_date = "2024-01-01"
+
+[observability]
+[observability.logs]
+enabled = false
+invocation_logs = true


### PR DESCRIPTION
Fixes IDT-40

## Summary
Adds observability configuration to `worker/wrangler.toml` to enable invocation logs for the feedback worker.

## After merging
A redeploy is required for this to take effect:
```bash
cd worker && wrangler deploy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)