### PR TITLE
IDT-41 Instrument pages and worker with full Cloudflare observability stack

### DIFF
--- a/index.html
+++ b/index.html
@@ -2739,6 +2739,9 @@ function showScreen(name) {
 }
 </script>
 
+<!-- Cloudflare Web Analytics — TODO: replace token via IDT-41 -->
+<script defer src='https://static.cloudflareinsights.com/beacon.min.js'
+  data-cf-beacon='{"token": "YOUR_CF_WEB_ANALYTICS_TOKEN"}'></script>
 
 </body>
 </html>

--- a/pages/feedback.html
+++ b/pages/feedback.html
@@ -411,5 +411,10 @@ async function submitFeedback() {
   }
 }
 </script>
+
+<!-- Cloudflare Web Analytics — TODO: replace token via IDT-41 -->
+<script defer src='https://static.cloudflareinsights.com/beacon.min.js'
+  data-cf-beacon='{"token": "YOUR_CF_WEB_ANALYTICS_TOKEN"}'></script>
+
 </body>
 </html>

--- a/worker/feedback-worker.js
+++ b/worker/feedback-worker.js
@@ -28,6 +28,7 @@ function corsHeaders(origin) {
 
 export default {
   async fetch(request, env) {
+    const startTime = Date.now();
     const origin = request.headers.get('Origin') || '*';
 
     // Handle CORS preflight
@@ -100,7 +101,7 @@ export default {
     }
 
     const issue = await response.json();
-    console.log(`Issue created: ${issue.html_url} from ${ip}`);
+    console.log(`Issue created: ${issue.html_url} from ${ip} in ${Date.now() - startTime}ms`);
     return new Response(JSON.stringify({ ok: true, url: issue.html_url }), {
       status: 200,
       headers: { 'Content-Type': 'application/json', ...corsHeaders(origin) },

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -3,6 +3,12 @@ main = "feedback-worker.js"
 compatibility_date = "2024-01-01"
 
 [observability]
+enabled = true
+
 [observability.logs]
 enabled = true
 invocation_logs = true
+
+[observability.traces]
+enabled = true
+head_sampling_rate = 1


### PR DESCRIPTION
Fixes IDT-41

## Summary

### Frontend — both pages
- Added Cloudflare Web Analytics beacon to `index.html` and `pages/feedback.html`
- Token placeholder `YOUR_CF_WEB_ANALYTICS_TOKEN` needs replacing before this is active
- Provides: page views, visits, Core Web Vitals (LCP, INP, CLS), FCP, full page load time breakdown, browser/OS/country segmentation

### Worker — wrangler.toml
- Added `[observability.traces]` with `head_sampling_rate = 1` (100% of requests traced)
- Added top-level `enabled = true` under `[observability]`
- Provides: automatic end-to-end request tracing, fetch call timing, handler lifecycle — visible in Cloudflare dashboard → Workers → feedback-worker → Traces

### Worker — feedback-worker.js
- Added `startTime` at request entry and included `in Xms` in the issue-created log line
- Every successful submission now logs its full round-trip duration to the GitHub API

## ⚠️ Token needed before Web Analytics is active
1. Cloudflare dashboard → **Web Analytics** → **Add site** → enter `galactic-math.pages.dev`
2. Copy the token
3. Replace `YOUR_CF_WEB_ANALYTICS_TOKEN` in both `index.html` and `pages/feedback.html`

## After merging
Run `cd worker && npx wrangler deploy` to activate the traces config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)