### PR TITLE
IDT-50 feedback page view existing link

### DIFF
--- a/pages/feedback.html
+++ b/pages/feedback.html
@@ -342,6 +342,25 @@
   }
 
   .confirm-body a:hover { text-decoration: underline; }
+
+  /* ===== PAGE FOOTER ===== */
+  .page-footer {
+    margin-top: 28px;
+    text-align: center;
+    font-family: 'Orbitron', monospace;
+    font-size: 9px;
+    letter-spacing: 3px;
+    color: var(--muted);
+    text-transform: uppercase;
+  }
+
+  .page-footer a {
+    color: var(--muted);
+    text-decoration: none;
+    transition: color 0.2s;
+  }
+
+  .page-footer a:hover { color: var(--saber-blue); }
 </style>
 </head>
 <body>
@@ -448,6 +467,12 @@
       </button>
     </div>
 
+  </div>
+
+  <div class="page-footer">
+    <a href="https://github.com/bmschimmel/galactic-math/issues" target="_blank" rel="noopener">
+      View existing requests on GitHub ↗
+    </a>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Adds a footer link at the bottom of `pages/feedback.html` to view existing GitHub issues
- Styled in muted Orbitron text consistent with the space theme, with a hover highlight to saber blue

## Test plan
- [ ] Open `pages/feedback.html` directly in a browser
- [ ] Confirm "View existing requests on GitHub ↗" link appears below the feedback card
- [ ] Confirm it opens `github.com/bmschimmel/galactic-math/issues` in a new tab
- [ ] Confirm link is visible across all three steps (category picker, form, confirmation)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)