### PR TITLE
IDT-100 Add GitHub repo link to footer and developer docs TOC to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ open index.html   # macOS
 
 ---
 
+## 📚 How It Works — Developer Docs
+
+| File | What it covers |
+|---|---|
+| [docs/overview.md](docs/overview.md) | Architecture, file structure, screens, global state, deployment |
+| [docs/setup.md](docs/setup.md) | Number selection, operation modes, game mode selection, Begin Mission |
+| [docs/quiz-engine.md](docs/quiz-engine.md) | Question generation, answer submission, nav dots, live score |
+| [docs/game-modes.md](docs/game-modes.md) | Standard, Hyperspace, and Kessel Run modes; rank system |
+| [docs/audio-engine.md](docs/audio-engine.md) | Web Audio API primitives and sound library |
+| [docs/visuals.md](docs/visuals.md) | Starfield, ring shockwave, comet celebration, hyperspace jump, CSS animations |
+| [docs/ui.md](docs/ui.md) | Theme cycler, session history, keyboard navigation, mobile support |
+| [docs/design-ux.md](docs/design-ux.md) | Design concept, color palette, typography, tone, wording, interaction patterns |
+| [docs/feedback-system.md](docs/feedback-system.md) | Feedback form, Cloudflare Worker, GitHub Issues integration |
+| [docs/CHANGELOG.md](docs/CHANGELOG.md) | Full history of changes by Linear issue and PR |
+
+---
+
 ## 🤝 Contributing
 
 Contributions? Yeah sure...it's a side project to help my kids learn math I don't know? Sure.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@ Each entry references the Linear issue ID (IDT-XX) and the GitHub PR that merged
 
 ---
 
+## 2026-04-13
+
+### IDT-100 — GitHub repo link in footer and developer docs TOC in README (PR #72)
+The "Created for fun." text in the app footer now links to the GitHub repository. The main `README.md` also gains a developer docs table of contents, mirroring `docs/README.md`, so contributors can find the right doc file without digging into the `docs/` folder first.
+
+---
+
 ## 2026-03-30
 
 ### IDT-65 — Even question distribution across operations (PR #70)

--- a/index.html
+++ b/index.html
@@ -1703,7 +1703,7 @@
   </div>
 
   <footer class="page-footer">
-    👨‍💻 Created for fun. &nbsp;·&nbsp;© <a href="https://www.linkedin.com/in/bmschimmel/" target="_blank" rel="noopener">Brendan Schimmel</a>
+    👨‍💻 <a href="https://github.com/bmschimmel/galactic-math" target="_blank" rel="noopener">Created for fun.</a> &nbsp;·&nbsp;© <a href="https://www.linkedin.com/in/bmschimmel/" target="_blank" rel="noopener">Brendan Schimmel</a>
 &nbsp;·&nbsp; <a href="pages/feedback.html"> 💬 Feedback</a> &nbsp;·&nbsp; <a href="pages/workflow.html"> 💡 How It Works</a>
     <div style="margin-top:4px; opacity:0.4;">v1.0.0</div>
   </footer>


### PR DESCRIPTION
## Summary

- Footer "Created for fun." text in `index.html` is now a hyperlink to the GitHub repo
- `README.md` gains a developer docs table of contents matching `docs/README.md`
- `docs/CHANGELOG.md` updated with IDT-100 entry

## Test plan

- [x] Open `index.html` in a browser, click "Created for fun." in the footer — should open the GitHub repo in a new tab
- [x] Verify the rest of the footer links (LinkedIn, Feedback, How It Works) still work
- [x] Check `README.md` renders correctly on GitHub — table should link to each doc file

Fixes IDT-100

🤖 Generated with [Claude Code](https://claude.com/claude-code)