### PR TITLE
IDT-103 Show Skipped instead of null for unanswered questions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ Each entry references the Linear issue ID (IDT-XX) and the GitHub PR that merged
 
 ---
 
+## 2026-04-13 (3)
+
+### IDT-103 — Show "Skipped" instead of "null" for unanswered questions (PR #TBD)
+Unanswered questions in the missed-problems review showed "You: null". The fix checks whether the recorded answer is null and displays "Skipped" instead, keeping the language friendly for kids.
+
 ## 2026-04-13 (2)
 
 ### IDT-101 — Race to Earth game mode (PR #74)

--- a/index.html
+++ b/index.html
@@ -2847,7 +2847,7 @@ function showResults() {
     list.innerHTML = missed.map(m =>
       `<div class="missed-item">
         <span class="missed-q">${m.q}</span>
-        <span class="missed-yours">You: ${m.yours}</span>
+        <span class="missed-yours">You: ${m.yours === null ? 'Skipped' : m.yours}</span>
         <span class="missed-correct">✓ ${m.correct}</span>
       </div>`
     ).join('');


### PR DESCRIPTION
Fixes IDT-103

Unanswered questions in the missed-problems review at the end of a session were showing "You: null" — the raw JavaScript null value being interpolated into the template string.

**Change:** In `showResults()`, the missed-item template now checks `m.yours === null` and renders "Skipped" instead.

**Tested in:** Chrome (Linux)
- Hyperspace mode with time running out leaves questions unanswered → results show "You: Skipped" for each
- Normally answered wrong questions still show the number the player entered