### PR TITLE
IDT-120 Add docking sound when advancing between question rings

### DIFF
--- a/index.html
+++ b/index.html
@@ -2053,10 +2053,9 @@ const sounds = {
     setTimeout(() => playFreqSweep(80, 20, 'sine', 0.4, 0.06), 700);
   },
   dock() {
-    // Magnetic docking clamp — descending approach swoosh + low lock thud
-    playFreqSweep(520, 180, 'sine', 0.14, 0.07);
-    setTimeout(() => playTone(140, 'sine', 0.26, 0.13), 65);
-    setTimeout(() => playTone(210, 'sine', 0.09, 0.07), 130);
+    // Descending approach pip + mid-range lock thud
+    playFreqSweep(720, 300, 'sine', 0.12, 0.22);
+    setTimeout(() => playTone(350, 'sine', 0.18, 0.28), 100);
   }
 };
 

--- a/index.html
+++ b/index.html
@@ -2051,6 +2051,12 @@ const sounds = {
     setTimeout(() => playFreqSweep(300, 40, 'sine', 0.5, 0.1), 300);
     setTimeout(() => playNoise(0.3, 0.04, 80), 500);
     setTimeout(() => playFreqSweep(80, 20, 'sine', 0.4, 0.06), 700);
+  },
+  dock() {
+    // Magnetic docking clamp — descending approach swoosh + low lock thud
+    playFreqSweep(520, 180, 'sine', 0.14, 0.07);
+    setTimeout(() => playTone(140, 'sine', 0.26, 0.13), 65);
+    setTimeout(() => playTone(210, 'sine', 0.09, 0.07), 130);
   }
 };
 
@@ -2867,7 +2873,10 @@ function submitAnswer() {
           if (answers[i] === null) { next = i; break; }
         }
       }
-      if (next !== -1) loadQuestion(next);
+      if (next !== -1) {
+        sounds.dock();
+        loadQuestion(next);
+      }
     }, 600);
   }
 }


### PR DESCRIPTION
## Summary
- Adds `sounds.dock()` — a brief magnetic docking clamp effect (descending swoosh + low bass thud) synthesized via Web Audio API
- Sound plays each time the player advances to the next unanswered question ring (nav dot) after submitting an answer
- Does not play on initial question load (which already has the missionStart launch sound) or on retry/restart

## Test plan
- [ ] Start a quiz session and answer a question — a short docking thud should play ~600ms after submitting (after correct/wrong tone fades)
- [ ] Verify it plays on every question advance throughout a full 20-question session
- [ ] Verify no sound plays on the very first question load or on Retry/New Mission
- [ ] Confirm existing correct/wrong/keypress/missionStart sounds are unaffected
- [ ] Test on mobile (tablet/phone)

Closes IDT-120

🤖 Generated with [Claude Code](https://claude.com/claude-code)