### PR TITLE
Add security.txt

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: https://github.com/bmschimmel/galactic-math/issues
+Expires: 2027-05-05T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://galacticmath.app/.well-known/security.txt


### PR DESCRIPTION
## Summary
- Adds `.well-known/security.txt` per RFC 9116
- Points reporters to GitHub Issues
- Expires 2027-05-05

## Test plan
- [ ] Visit `https://galacticmath.app/.well-known/security.txt` after deploy and confirm the file is served

🤖 Generated with [Claude Code](https://claude.com/claude-code)