### PR TITLE
IDT-131 Make all alien ships red

### DIFF
--- a/pages/alien-invasion.html
+++ b/pages/alien-invasion.html
@@ -1551,7 +1551,7 @@ function generateObstacles() {
     const a = Math.random()*Math.PI*2;
     const alienIndex = obs.filter(o=>o.type==='alien').length;
     const isShooter = alienIndex < N_ALIENS / 2; // first half are shooters
-    obs.push({ type:'alien', x, y, radius:22, vx:Math.cos(a)*(0.6+Math.random()*0.65), vy:Math.sin(a)*(0.6+Math.random()*0.65), wobble:Math.random()*Math.PI*2, color:isShooter?'#ff2d55':'#39ff14', isShooter, nextShot: Date.now() + 4000 + Math.random() * 5000 });
+    obs.push({ type:'alien', x, y, radius:22, vx:Math.cos(a)*(0.6+Math.random()*0.65), vy:Math.sin(a)*(0.6+Math.random()*0.65), wobble:Math.random()*Math.PI*2, color:'#ff2d55', isShooter, nextShot: Date.now() + 4000 + Math.random() * 5000 });
   }
   return obs;
 }
@@ -2890,7 +2890,7 @@ function drawRadar() {
     return { x: mx + (wx / WORLD_W) * mw, y: my + (wy / WORLD_H) * mh };
   }
 
-  // Aliens — pulsing, colored by type (red=shooter, green=non-shooter)
+  // Aliens — pulsing, all red
   const pulse = 0.7 + 0.3 * Math.sin(Date.now() / 400);
   for (const obs of aliens) {
     const r = toR(obs.x, obs.y);


### PR DESCRIPTION
## Summary
- Change non-shooter alien color from green (`#39ff14`) to red (`#ff2d55`)
- Shooter/non-shooter ratio is unchanged — `isShooter` flag still controls behavior
- Updated radar minimap comment to reflect all aliens are now red

## Test plan
- [x] Open `pages/alien-invasion.html` and start a game
- [x] Confirm all alien ships appear red (not green)
- [x] Confirm shooter aliens still fire at the player
- [x] Confirm non-shooters still move without firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)