### PR TITLE
IDT-142 Docs audit: remove Academy branding, sync docs with recent features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Galactic Math Academy
+# Contributing to Galactic Math
 
 ## Workflow Overview
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Galactic Math Academy
+# Galactic Math
 Space themed math trainer for elementary school kids
 
 ![Galactic Math](https://img.shields.io/badge/grade-K--6-blue?style=flat-square) ![License](https://img.shields.io/badge/license-MIT-green?style=flat-square) ![No dependencies](https://img.shields.io/badge/dependencies-none-brightgreen?style=flat-square)
@@ -14,6 +14,7 @@ Space themed math trainer for elementary school kids
 - **Comet celebration** — passing scores (75%+) trigger streaking comets across the screen
 - **Hyperspace mode** — optional timed challenge: complete all 20 before the countdown hits zero (Wicked Easy / Harder / Hyperdrive)
 - **Kessel Run mode** — race against the clock; wrong answers add a 5-second penalty
+- **Alien Invasion mode** — canvas-based space shooter; pilot your rocket through 20 math gates, dodge asteroids and UFOs, and manage your oxygen supply
 - **Theme cycler** — switch between Dark, Dim, Midnight, Deep Blue, and Retro color themes
 - **Session history** — track your scores across all rounds without any persistent storage
 - **Live grading** — see your score as you go, full breakdown at the end with missed problems reviewed
@@ -24,7 +25,7 @@ Space themed math trainer for elementary school kids
 
 ## 🚀 Play It Now
 
-👉 **[Launch Galactic Math Academy](https://galacticmath.app/)**
+👉 **[Launch Galactic Math](https://galacticmath.app/)**
 
 Or download `index.html` and open it in any modern browser.
 
@@ -61,7 +62,7 @@ open index.html   # macOS
 | [docs/overview.md](docs/overview.md) | Architecture, file structure, screens, global state, deployment |
 | [docs/setup.md](docs/setup.md) | Number selection, operation modes, game mode selection, Begin Mission |
 | [docs/quiz-engine.md](docs/quiz-engine.md) | Question generation, answer submission, nav dots, live score |
-| [docs/game-modes.md](docs/game-modes.md) | Standard, Hyperspace, and Kessel Run modes; rank system |
+| [docs/game-modes.md](docs/game-modes.md) | Standard, Hyperspace, Kessel Run, and Alien Invasion modes; rank system |
 | [docs/audio-engine.md](docs/audio-engine.md) | Web Audio API primitives and sound library |
 | [docs/visuals.md](docs/visuals.md) | Starfield, ring shockwave, comet celebration, hyperspace jump, CSS animations |
 | [docs/ui.md](docs/ui.md) | Theme cycler, session history, keyboard navigation, mobile support |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to Galactic Math Academy are listed here, newest first.
+All notable changes to Galactic Math are listed here, newest first.
 Each entry references the Linear issue ID (IDT-XX) and the GitHub PR that merged it.
 
 ---
@@ -14,6 +14,14 @@ Added a themed transmission sound effect to the "📡 TRANSMIT FEEDBACK" button 
 ---
 
 ## 2026-05-11
+
+### IDT-142 — Docs audit: remove "Academy" branding, sync docs with recent work (PR #TBD)
+
+Removed all occurrences of "Galactic Math Academy" from documentation, page titles, and link text across `docs/`, `README.md`, `CONTRIBUTING.md`, and `pages/`. The banner in the app already used "GALACTIC MATH"; the docs were just stale. Also filled documentation gaps introduced by recent issues: added an Alien Invasion mode section to `docs/game-modes.md`, added Alien Invasion touch-control details to `docs/ui.md`, documented the IDT-134 feedback audio in `docs/feedback-system.md`, and added the Alien Invasion game mode to `README.md`'s feature list.
+
+### IDT-141 — Fix OG image letterboxing and og:title length (PR #107)
+
+Rebuilt `og-image.png` using `logo-planet-only.png` (transparent background) composited on a full-bleed dark-navy gradient canvas with scattered stars and nebula blobs, eliminating the black letterbox bars that appeared in social share previews after IDT-109. Expanded `og:title`, `twitter:title`, and `<title>` from 21 characters ("Galactic Math Academy") to 55 characters ("Galactic Math — Space themed free math trainer for kids"), meeting the 30–60 character guideline for social validators.
 
 ### IDT-109 — Replace favicons and OG image with new branded logo (PR #TBD)
 
@@ -103,7 +111,7 @@ Added the Galactic Math favicon (SVG inline) to `pages/feedback.html` and `pages
 
 ### IDT-57 — Banner click returns to setup (PR #62)
 
-Clicking the "Galactic Math Academy" header banner now navigates back to the setup screen from any screen. Previously the banner was non-interactive.
+Clicking the "GALACTIC MATH" header banner now navigates back to the setup screen from any screen. Previously the banner was non-interactive.
 
 ### IDT-56 — Switch feedback title generation to Cloudflare Workers AI (PR #61)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# Galactic Math Academy — Documentation
+# Galactic Math — Documentation
 
-This folder contains developer documentation explaining how each part of Galactic Math Academy works.
+This folder contains developer documentation explaining how each part of Galactic Math works.
 
 ---
 

--- a/docs/feedback-system.md
+++ b/docs/feedback-system.md
@@ -71,6 +71,12 @@ A lightweight edge function that sits between the feedback form and GitHub.
 
 ---
 
+## Feedback Page Audio (IDT-134)
+
+The "📡 TRANSMIT FEEDBACK" submit button plays a themed transmission sound on click. The sound is synthesized via a self-contained Web Audio engine inlined directly in `pages/feedback.html` (the page does not load `game.js`). The effect is an ascending radio-chirp sweep followed by two short confirmation beeps, mimicking a signal being beamed out.
+
+---
+
 ## Workflow Page (`pages/workflow.html`)
 
 A separate informational page (linked from the footer) that explains the development workflow — how issues flow from user feedback through Linear to a merged PR. Not part of the core game; intended for contributors and curious users.

--- a/docs/game-modes.md
+++ b/docs/game-modes.md
@@ -71,6 +71,48 @@ A **comet celebration** plays on a passing score (≥75%).
 
 ---
 
+## Alien Invasion Mode
+
+A canvas-based space shooter at `pages/alien-invasion.html`. Selected numbers and operations are passed in via URL params (`nums`, `ops`) by the main setup screen.
+
+### Objective
+
+Pilot a rocket through 20 math gates scattered around the canvas. Answer each gate's question correctly to clear it. All gates must be cleared (in any order) to win.
+
+### Resources
+
+| Resource | Starting value | Notes |
+|---|---|---|
+| Oxygen | 100% | Drains continuously while thrusting; wrong answers cost −5% |
+| Lives | 5 | Lost by colliding with asteroids, UFO saucers, or comets |
+
+### Hazards
+
+- **Asteroids** — drifting rocks; collision causes screen shake and debris particles
+- **UFO saucers** — cause a multi-layered explosion on hit (boom, noise burst, alien screech, colorful particles)
+- **Comets** — streak across the canvas from random directions with glowing color trails
+
+### Bonus gates
+
+Three rainbow-colored gates require 3 correct answers each. Completing one refuels +10% O₂.
+
+### Audio warning
+
+When oxygen drops to 10%, a "low fuel" voice clip plays followed by rising-pitch tick sounds every second. The warning re-triggers after a refuel pickup.
+
+### Controls
+
+| Input | Action |
+|---|---|
+| Arrow keys / WASD | Thrust in direction |
+| Space | Fire missile |
+| Touch D-pad (bottom-left) | Directional thrust on touch devices |
+| Touch fire button (bottom-right) | Fire missile on touch devices |
+
+A pulsing directional arrow points toward the nearest uncleaned gate when it is off-screen.
+
+---
+
 ## Celebration Threshold
 
 All modes trigger a celebration when the score is **≥75% (15/20 questions correct)**. Hyperspace mode uses its own completion animation instead of a separate celebration.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,6 @@
-# Galactic Math Academy — Architecture Overview
+# Galactic Math — Architecture Overview
 
-Galactic Math Academy is a space-themed math trainer for kids in grades K–6. The entire game is a **single HTML file** (`index.html`) with no build step, no external dependencies (beyond Google Fonts), and no server requirement. It runs entirely in the browser.
+Galactic Math is a space-themed math trainer for kids in grades K–6. The entire game is a **single HTML file** (`index.html`) with no build step, no external dependencies (beyond Google Fonts), and no server requirement. It runs entirely in the browser.
 
 ---
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -58,7 +58,7 @@ A floating button (clock icon) in the top-right area opens a modal showing the s
 
 ## Banner Clicking
 
-Clicking the **Galactic Math Academy** header banner from any screen returns to the setup screen. This makes it easy for kids to restart without hunting for a button.
+Clicking the **GALACTIC MATH** header banner from any screen returns to the setup screen. This makes it easy for kids to restart without hunting for a button.
 
 ---
 
@@ -77,3 +77,7 @@ The layout is responsive down to ~375px wide. Key mobile considerations:
 - Operation mode buttons and game mode tiles are centered on small screens
 - The answer input is large and touch-friendly
 - A dedicated **Submit** button appears for touch users (Enter still works on keyboard)
+
+### Alien Invasion touch controls
+
+On touch devices, `pages/alien-invasion.html` renders a virtual D-pad (bottom-left) and a fire button (bottom-right). These wire into the same `keys[]` state used by keyboard input so all physics and audio remain unchanged. A pause button is also overlaid on-screen. The planet fact popup dismisses on tap. Responsive CSS (`≤600px`) shrinks the HUD bar, question text, and answer input for small phones, and stacks end-screen buttons vertically.

--- a/og-image.svg
+++ b/og-image.svg
@@ -44,10 +44,6 @@
   <text x="600" y="345" font-family="'Ubuntu', Arial Black, sans-serif" font-size="78" font-weight="900"
         fill="url(#titleGrad)" text-anchor="middle" letter-spacing="5">GALACTIC MATH</text>
 
-  <!-- Subtitle -->
-  <text x="600" y="437" font-family="'Ubuntu', Arial, sans-serif" font-size="30" font-weight="700"
-        fill="#00d4ff" text-anchor="middle" letter-spacing="14" opacity="0.9">ACADEMY</text>
-
   <!-- Tagline -->
   <text x="600" y="498" font-family="Arial, sans-serif" font-size="22"
         fill="#6b7fa3" text-anchor="middle" letter-spacing="2">Space-themed math training for kids</text>

--- a/pages/alien-invasion.html
+++ b/pages/alien-invasion.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Alien Invasion — Galactic Math Academy</title>
+<title>Alien Invasion — Galactic Math</title>
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='4' fill='%23030712'/%3E%3Ccircle cx='16' cy='16' r='7' fill='%231a2744' stroke='%2300d4ff' stroke-width='1.5'/%3E%3Cellipse cx='16' cy='16' rx='12' ry='4.5' fill='none' stroke='%23ffd700' stroke-width='1.5' opacity='0.9'/%3E%3Ccircle cx='7' cy='8' r='1.2' fill='%23e8f4ff' opacity='0.7'/%3E%3Ccircle cx='26' cy='7' r='1' fill='%23e8f4ff' opacity='0.5'/%3E%3Ccircle cx='27' cy='24' r='1.2' fill='%23e8f4ff' opacity='0.6'/%3E%3C/svg%3E">
 <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Exo+2:wght@300;400;600&display=swap" rel="stylesheet">
 <style>

--- a/pages/feedback.html
+++ b/pages/feedback.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Send Feedback — Galactic Math Academy</title>
+<title>Send Feedback — Galactic Math</title>
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='4' fill='%23030712'/%3E%3Ccircle cx='16' cy='16' r='7' fill='%231a2744' stroke='%2300d4ff' stroke-width='1.5'/%3E%3Cellipse cx='16' cy='16' rx='12' ry='4.5' fill='none' stroke='%23ffd700' stroke-width='1.5' opacity='0.9'/%3E%3Ccircle cx='7' cy='8' r='1.2' fill='%23e8f4ff' opacity='0.7'/%3E%3Ccircle cx='26' cy='7' r='1' fill='%23e8f4ff' opacity='0.5'/%3E%3Ccircle cx='27' cy='24' r='1.2' fill='%23e8f4ff' opacity='0.6'/%3E%3C/svg%3E">
 <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Exo+2:wght@300;400;600&display=swap" rel="stylesheet">
 <style>

--- a/pages/workflow.html
+++ b/pages/workflow.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How It Works — Galactic Math Academy</title>
+  <title>How It Works — Galactic Math</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='4' fill='%23030712'/%3E%3Ccircle cx='16' cy='16' r='7' fill='%231a2744' stroke='%2300d4ff' stroke-width='1.5'/%3E%3Cellipse cx='16' cy='16' rx='12' ry='4.5' fill='none' stroke='%23ffd700' stroke-width='1.5' opacity='0.9'/%3E%3Ccircle cx='7' cy='8' r='1.2' fill='%23e8f4ff' opacity='0.7'/%3E%3Ccircle cx='26' cy='7' r='1' fill='%23e8f4ff' opacity='0.5'/%3E%3Ccircle cx='27' cy='24' r='1.2' fill='%23e8f4ff' opacity='0.6'/%3E%3C/svg%3E">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Exo+2:wght@300;400;600&display=swap" rel="stylesheet">
   <style>
@@ -384,7 +384,7 @@
 </head>
 <body>
 
-  <a href="../index.html" class="back-link">← Back to Galactic Math Academy</a>
+  <a href="../index.html" class="back-link">← Back to Galactic Math</a>
 
   <h1>How It Works</h1>
   <p class="subtitle">GitHub · Linear · Claude Code · Cloudflare</p>
@@ -733,7 +733,7 @@
   </div><!-- /flows-wrap -->
 
   <footer class="page-footer">
-    <a href="../index.html">← Galactic Math Academy</a> &nbsp;·&nbsp; © Brendan Schimmel
+    <a href="../index.html">← Galactic Math</a> &nbsp;·&nbsp; © Brendan Schimmel
   </footer>
 
   <script>


### PR DESCRIPTION
## Summary

- Removes every occurrence of "Galactic Math Academy" from docs, page titles, link text, og-image.svg, and CONTRIBUTING.md — the in-app banner already reads "GALACTIC MATH" so these were all stale
- Fills documentation gaps left by the Alien Invasion game mode (IDT-101 through IDT-132 shipped it with no developer docs): new Alien Invasion section in `docs/game-modes.md`, touch-control details added to `docs/ui.md`
- Documents the IDT-134 feedback-button audio in `docs/feedback-system.md`
- Adds Alien Invasion to the `README.md` feature list and updates the docs table description for `game-modes.md`
- Adds CHANGELOG entries for IDT-141 and IDT-142

## Test plan

- [ ] `grep -ri "academy" docs/ README.md CONTRIBUTING.md pages/ og-image.svg` returns nothing
- [ ] `docs/game-modes.md` Alien Invasion section is accurate against `pages/alien-invasion.html`
- [ ] `docs/ui.md` touch-control section matches actual D-pad behaviour on a touch device or DevTools emulation
- [ ] README features list reads correctly in GitHub's rendered Markdown view

Fixes IDT-142

🤖 Generated with [Claude Code](https://claude.com/claude-code)