### PR TITLE
Update OG image to v2

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
 <meta property="og:url" content="https://galacticmath.app/">
 <meta property="og:title" content="Galactic Math — Space themed free math trainer for kids">
 <meta property="og:description" content="Space-themed math training for kids. Practice multiplication, division, addition, and subtraction with lightsabers, droids, and starships. Free, no login required.">
-<meta property="og:image" content="https://galacticmath.app/og-image.png">
-<meta property="og:image:secure_url" content="https://galacticmath.app/og-image.png">
+<meta property="og:image" content="https://galacticmath.app/og-image-v2.png">
+<meta property="og:image:secure_url" content="https://galacticmath.app/og-image-v2.png">
 <meta property="og:image:type" content="image/png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -23,7 +23,7 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Galactic Math — Space themed free math trainer for kids">
 <meta name="twitter:description" content="Space-themed math training for kids. Practice multiplication, division, addition, and subtraction with lightsabers, droids, and starships. Free, no login required.">
-<meta name="twitter:image" content="https://galacticmath.app/og-image.png">
+<meta name="twitter:image" content="https://galacticmath.app/og-image-v2.png">
 
 <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Exo+2:wght@300;400;600&display=swap" rel="stylesheet">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">


### PR DESCRIPTION
Swaps all OG/Twitter meta tag references from `og-image.png` to `og-image-v2.png` to bust platform caches and surface the new design.